### PR TITLE
Add explicit numpy requirement < 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy<2
 opencv-python>=4.8.1.78
 typing-extensions>=4.4.0
 ultralytics==8.3.26


### PR DESCRIPTION
When using the Dockerfile, there is an issue that numpy 2.X gets installed as a dependency which conflicts with the usage of cv_bridge that is compiled with numpy 1.X.

[cv_bridge issue](https://github.com/ros-perception/vision_opencv/issues/535)