### PR TITLE
debug_node: Use the input message header as header of the debug message

### DIFF
--- a/yolo_ros/yolo_ros/debug_node.py
+++ b/yolo_ros/yolo_ros/debug_node.py
@@ -368,7 +368,8 @@ class DebugNode(LifecycleNode):
                     kp_marker_array.markers.append(marker)
 
         # publish dbg image
-        self._dbg_pub.publish(self.cv_bridge.cv2_to_imgmsg(cv_image, encoding="bgr8"))
+        self._dbg_pub.publish(self.cv_bridge.cv2_to_imgmsg(cv_image, encoding="bgr8",
+                                                           header=img_msg.header))
         self._bb_markers_pub.publish(bb_marker_array)
         self._kp_markers_pub.publish(kp_marker_array)
 


### PR DESCRIPTION
I am using the `yolo_ros` in a project and I appreciate your support.

I noticed that the `/dbg_image` message had an empty header (timestamp and `frame_id`), which caused issues in RViz. To resolve this, I copied the header from the input message to `/dbg_image`.
