### PR TITLE
Add YOLOE Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The compatible models for yolo_ros are the following:
 - [YOLOv11](https://docs.ultralytics.com/models/yolo11/)
 - [YOLOv12](https://docs.ultralytics.com/models/yolo12/)
 - [YOLO-World](https://docs.ultralytics.com/models/yolo-world/)
+- [YOLOE](https://docs.ultralytics.com/models/yoloe/)
 
 ## Usage
 
@@ -112,6 +113,12 @@ ros2 launch yolo_bringup yolov12.launch.py
 
 ```shell
 ros2 launch yolo_bringup yolo-world.launch.py
+```
+
+### YOLOE
+
+```shell
+ros2 launch yolo_bringup yoloe.launch.py
 ```
 
 </details>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy<2
 opencv-python>=4.8.1.78
 typing-extensions>=4.4.0
-ultralytics==8.3.91
+ultralytics==8.3.168
 lap>=0.5.12

--- a/yolo_bringup/launch/yolo.launch.py
+++ b/yolo_bringup/launch/yolo.launch.py
@@ -32,8 +32,8 @@ def generate_launch_description():
         model_type_cmd = DeclareLaunchArgument(
             "model_type",
             default_value="YOLO",
-            choices=["YOLO", "World"],
-            description="Model type form Ultralytics (YOLO, World)",
+            choices=["YOLO", "World", "YOLOE"],
+            description="Model type form Ultralytics (YOLO, World, YOLOE)",
         )
 
         model = LaunchConfiguration("model")

--- a/yolo_bringup/launch/yoloe.launch.py
+++ b/yolo_bringup/launch/yoloe.launch.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2023 Miguel Ángel González Santamarta
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import os
+from launch import LaunchDescription
+from launch.substitutions import LaunchConfiguration
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from ament_index_python.packages import get_package_share_directory
+
+
+def generate_launch_description():
+
+    return LaunchDescription(
+        [
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    os.path.join(
+                        get_package_share_directory("yolo_bringup"),
+                        "launch",
+                        "yolo.launch.py",
+                    )
+                ),
+                launch_arguments={
+                    "model_type": "YOLOE",
+                    "model": LaunchConfiguration("model", default="yoloe-11l-seg-pf.pt"),
+                    "tracker": LaunchConfiguration("tracker", default="bytetrack.yaml"),
+                    "device": LaunchConfiguration("device", default="cuda:0"),
+                    "enable": LaunchConfiguration("enable", default="True"),
+                    "threshold": LaunchConfiguration("threshold", default="0.5"),
+                    "input_image_topic": LaunchConfiguration(
+                        "input_image_topic", default="/camera/rgb/image_raw"
+                    ),
+                    "image_reliability": LaunchConfiguration(
+                        "image_reliability", default="1"
+                    ),
+                    "namespace": LaunchConfiguration("namespace", default="yolo"),
+                }.items(),
+            )
+        ]
+    )

--- a/yolo_ros/yolo_ros/tracking_node.py
+++ b/yolo_ros/yolo_ros/tracking_node.py
@@ -31,7 +31,7 @@ from cv_bridge import CvBridge
 from ultralytics.engine.results import Boxes
 from ultralytics.trackers.basetrack import BaseTrack
 from ultralytics.trackers import BOTSORT, BYTETracker
-from ultralytics.utils import IterableSimpleNamespace, yaml_load
+from ultralytics.utils import IterableSimpleNamespace, YAML
 from ultralytics.utils.checks import check_requirements, check_yaml
 
 from sensor_msgs.msg import Image
@@ -131,7 +131,7 @@ class TrackingNode(LifecycleNode):
         check_requirements("lap")  # for linear_assignment
 
         tracker = check_yaml(tracker_yaml)
-        cfg = IterableSimpleNamespace(**yaml_load(tracker))
+        cfg = IterableSimpleNamespace(**YAML.load(tracker))
 
         assert cfg.tracker_type in [
             "bytetrack",

--- a/yolo_ros/yolo_ros/yolo_node.py
+++ b/yolo_ros/yolo_ros/yolo_node.py
@@ -28,7 +28,7 @@ from rclpy.lifecycle import TransitionCallbackReturn
 from rclpy.lifecycle import LifecycleState
 
 import torch
-from ultralytics import YOLO, YOLOWorld
+from ultralytics import YOLO, YOLOWorld, YOLOE
 from ultralytics.engine.results import Results
 from ultralytics.engine.results import Boxes
 from ultralytics.engine.results import Masks
@@ -69,7 +69,7 @@ class YoloNode(LifecycleNode):
         self.declare_parameter("agnostic_nms", False)
         self.declare_parameter("retina_masks", False)
 
-        self.type_to_model = {"YOLO": YOLO, "World": YOLOWorld}
+        self.type_to_model = {"YOLO": YOLO, "World": YOLOWorld, "YOLOE": YOLOE}
 
     def on_configure(self, state: LifecycleState) -> TransitionCallbackReturn:
         self.get_logger().info(f"[{self.get_name()}] Configuring...")
@@ -136,11 +136,13 @@ class YoloNode(LifecycleNode):
             self.get_logger().error(f"Model file '{self.model}' does not exists")
             return TransitionCallbackReturn.ERROR
 
-        try:
-            self.get_logger().info("Trying to fuse model...")
-            self.yolo.fuse()
-        except TypeError as e:
-            self.get_logger().warn(f"Error while fuse: {e}")
+        # YOLOE does not support fusing
+        if isinstance(self.yolo, YOLO) or isinstance(self.yolo, YOLOWorld):
+            try:
+                self.get_logger().info("Trying to fuse model...")
+                self.yolo.fuse()
+            except TypeError as e:
+                self.get_logger().warn(f"Error while fuse: {e}")
 
         self._enable_srv = self.create_service(SetBool, "enable", self.enable_cb)
 


### PR DESCRIPTION
These changes enable the usage of YOLOE models with `yolo_ros`. Specifically:

- update `ultralytics` dependency and fix breaking changes (yaml loader API was changed)
- introduce new model type: `YOLOE`
- only fuse YOLO and YOLO-WORLD models since fusing will break inference for YOLOE


close #97 