### PR TITLE
Fixes working directory in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ FROM deps AS builder
 SHELL ["/bin/bash", "-c"]
 
 # Build the workspace
+WORKDIR /root/ros2_ws
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash && colcon build
 
 # Source the ROS 2 setup file


### PR DESCRIPTION
When using the package from Docker I noticed that `colcon build` gets invoked in `/root/ros2_ws/src/yolo_ros`.

This is not the intended behavior as we also see a few lines below: 
```dockerfile
RUN echo "source /root/ros2_ws/install/setup.bash" >> ~/.bashrc
```

This PR adds a simple `WORKDIR` command before `colcon build`. 