### PR TITLE
Partial revert of commit enforcing 'uv' tool

### DIFF
--- a/yolo_bringup/launch/yolo.launch.py
+++ b/yolo_bringup/launch/yolo.launch.py
@@ -14,16 +14,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-import os
-import glob
-import subprocess
-
 from launch import LaunchDescription, LaunchContext
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 from launch.conditions import IfCondition
-from ament_index_python.packages import get_package_share_directory
 
 
 def generate_launch_description():
@@ -32,14 +27,6 @@ def generate_launch_description():
 
         use_tracking = eval(context.perform_substitution(use_tracking))
         use_3d = eval(context.perform_substitution(use_3d))
-
-        share_dir = get_package_share_directory("yolo_ros")
-        subprocess.run(["uv", "sync", "--project", share_dir], check=True)
-        venv_site_pkgs = glob.glob(
-            os.path.join(share_dir, ".venv", "lib", "python*", "site-packages")
-        )
-        existing_pythonpath = os.environ.get("PYTHONPATH", "")
-        new_pythonpath = ":".join(venv_site_pkgs + [existing_pythonpath]).strip(":")
 
         model_type = LaunchConfiguration("model_type")
         model_type_cmd = DeclareLaunchArgument(
@@ -244,7 +231,6 @@ def generate_launch_description():
             executable="yolo_node",
             name="yolo_node",
             namespace=namespace,
-            additional_env={"PYTHONPATH": new_pythonpath},
             parameters=[
                 {
                     "model_type": model_type,
@@ -273,7 +259,6 @@ def generate_launch_description():
             executable="tracking_node",
             name="tracking_node",
             namespace=namespace,
-            additional_env={"PYTHONPATH": new_pythonpath},
             parameters=[{"tracker": tracker, "image_reliability": image_reliability}],
             remappings=[("image_raw", input_image_topic)],
             condition=IfCondition(PythonExpression([str(use_tracking)])),
@@ -284,7 +269,6 @@ def generate_launch_description():
             executable="detect_3d_node",
             name="detect_3d_node",
             namespace=namespace,
-            additional_env={"PYTHONPATH": new_pythonpath},
             parameters=[
                 {
                     "target_frame": target_frame,
@@ -306,7 +290,6 @@ def generate_launch_description():
             executable="debug_node",
             name="debug_node",
             namespace=namespace,
-            additional_env={"PYTHONPATH": new_pythonpath},
             parameters=[{"image_reliability": image_reliability}],
             remappings=[
                 ("image_raw", input_image_topic),

--- a/yolo_ros/setup.py
+++ b/yolo_ros/setup.py
@@ -9,7 +9,6 @@ setup(
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
         ("share/" + package_name, ["package.xml"]),
-        ("share/" + package_name, ["../pyproject.toml"]),
     ],
     install_requires=["setuptools"],
     zip_safe=True,


### PR DESCRIPTION
This PR modifies the users environment (`uv sync`) and forces the `uv` tool on users.

We're not using `uv` so this broke the launchfile for us. (Thanks for this package in the first place btw :slightly_smiling_face: )

Can you explain what you were trying to solve? Perhaps there is another way. But in the meantime I think this should be reverted.

It's kind of a-typical to call subprocesses in a launchfile like this.