### PR TITLE
Fix numpy 2 incompatibilities on Ubuntu 26.04

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "4.6.1"
 description = "ROS 2 wrap for YOLO models from Ultralytics"
 requires-python = ">=3.10"
 dependencies = [
-    "numpy<2",
+    "numpy>=1.26",
     "opencv-python-headless>=4.8.1.78",
     "typing-extensions>=4.4.0",
     "ultralytics==8.4.6",

--- a/yolo_ros/yolo_ros/debug_node.py
+++ b/yolo_ros/yolo_ros/debug_node.py
@@ -229,7 +229,7 @@ class DebugNode(LifecycleNode):
         )
 
         # Rotate the corners of the rectangle
-        rect_pts = np.int0(cv2.transform(np.array([rect_pts]), rotation_matrix)[0])
+        rect_pts = np.intp(cv2.transform(np.array([rect_pts]), rotation_matrix)[0])
 
         # Draw the rotated rectangle
         for i in range(4):

--- a/yolo_ros/yolo_ros/tracking_node.py
+++ b/yolo_ros/yolo_ros/tracking_node.py
@@ -255,7 +255,7 @@ class TrackingNode(LifecycleNode):
                     # Get track ID
                     track_id = ""
                     if tracked_box.is_track:
-                        track_id = str(int(tracked_box.id))
+                        track_id = str(int(np.asarray(tracked_box.id).item()))
                     tracked_detection.id = track_id
 
                     # Append msg


### PR DESCRIPTION
On ROS 2 Lyrical (Ubuntu 26.04 / Python 3.14), `detect_3d_node` crashes as soon as depth data reaches it.
The root cause seems to be the `numpy<2` pin in `pyproject.toml` as well as the use of `np.int0`.

There is no numpy<2 wheel for Python 3.13+, so on Python 3.14 the pin forces numpy 1.26.4 to be built against an unsupported Python. That build miscomputes histogram bin indices, and detect_3d_node dies with "operands could not be broadcast together with shapes (60,) (62,) (60,)" on the first synchronized depth frame.

Proposed fix: drop the upper bound so each Python resolves to a numpy that ships a wheel, and fix the two numpy 2 incompatibilities this exposes:

- debug_node: np.int0 was removed in numpy 2.0 (alias for intp)
- tracking_node: numpy 2 rejects int() on a one-element array

Both code changes remain compatible with numpy 1.x.

## Testing

Verified on ROS 2 Lyrical / Ubuntu 26.04 / Python 3.14 / numpy 2.5.1, with a RealSense D435 publishing aligned depth.

Before: `detect_3d_node` dies on the first synchronized depth frame.
After: all four nodes stay up; `/yolo/detections_3d` publishes populated `bbox3d` fields and `/yolo/dgb_bb_markers` renders in RViz.